### PR TITLE
Grafana resources config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@ To configure the plugin you will need the following details of the grafana cloud
 | `organisation`    | The organisation name in grafana cloud (e.g. https://grafana.com/orgs/<organisation>)                                                                                                           |
 | `key`             | An admin API key that is used by the plugin authenticate with the grafana cloud api                                                                                                             | 
 | `url`             | The url or the grafana cloud api (usually `https://grafana.com/api/`)                                                                                                                           | 
-| `user` (optional) | The user ID that is used to authenticate with the grafana cloud prometheus endpoint. There is only one of these per organisation see the grafana cloud organisation dashboard for more details. | 
+| `user` (optional) | (Deprecated) The user ID that is used to authenticate with the grafana cloud prometheus endpoint. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `prometheus_user` (optional) | The user ID that is used to authenticate with the grafana cloud prometheus endpoint. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `prometheus_url` (optional) | The URL at which Prometheus can be accessed. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `loki_user` (optional) | The user ID that is used to authenticate with the grafana cloud loki endpoint. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `loki_url` (optional) | The URL at which Loki can be accessed. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `tempo_user` (optional) | The user ID that is used to authenticate with the grafana cloud tempo endpoint. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `tempo_url` (optional) | The URL at which Tempo can be accessed. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `alertmanager_user` (optional) | The user ID that is used to authenticate with the grafana cloud alertmanager endpoint. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `alertmanager_url` (optional) | The URL at which Alertmanager can be accessed. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `graphite_user` (optional) | The user ID that is used to authenticate with the grafana cloud graphite endpoint. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
+| `graphite_url` (optional) | The URL at which Graphite can be accessed. There is only one of these per stack see the grafana cloud stack dashboard for more details. | 
 
 Configure the plugin with the details of the grafana cloud organisation:
 
@@ -71,6 +81,8 @@ Valid values for `gc_role` are `Viewer`, `Admin`, `Editor`, `MetricsPublisher`, 
 
 2. Retrieve a new grafana cloud API key from Vault
 
+Any user/url configuration provided to the backend will be populated on the credential.
+
 ```shell
 vault read grafanacloud/creds/examplerole 
 
@@ -88,4 +100,18 @@ user               $CONFIGURED_USER_ID
 ```shell
 # List stacks
 curl -H "Authorization: Bearer $GRAFANA_CLOUD_TOKEN" https://grafana.com/api/orgs/<org_slug>/instances
+```
+
+## Testing
+
+Tests can be run using `make test`.
+
+To run the integration tests, you need to set some environment variables:
+
+```
+VAULT_ACC=1
+TEST_GRAFANA_CLOUD_ORGANISATION=my-org
+TEST_GRAFANA_CLOUD_API_KEY=<token>
+TEST_GRAFANA_CLOUD_URL=https://grafana.com/api
+TEST_GRAFANA_CLOUD_CA_TAR_PATH=<optional path to tar archive containing CA file if required for making HTTP requests from a docker container>
 ```

--- a/backend_test.go
+++ b/backend_test.go
@@ -44,10 +44,19 @@ var runAcceptanceTests = os.Getenv(envVarRunAccTests) == "1"
 // resources
 type testEnv struct {
 	// Password string
-	Organisation string
-	Key          string
-	URL          string
-	User         string
+	Organisation     string
+	Key              string
+	URL              string
+	PrometheusUser   string
+	PrometheusURL    string
+	LokiUser         string
+	LokiURL          string
+	TempoUser        string
+	TempoURL         string
+	AlertmanagerUser string
+	AlertmanagerURL  string
+	GraphiteUser     string
+	GraphiteURL      string
 
 	Backend logical.Backend
 	Context context.Context
@@ -69,10 +78,19 @@ func (e *testEnv) AddConfig(t *testing.T) {
 		Path:      "config",
 		Storage:   e.Storage,
 		Data: map[string]interface{}{
-			"organisation": e.Organisation,
-			"key":          e.Key,
-			"url":          e.URL,
-			"user":         e.User,
+			"organisation":      e.Organisation,
+			"key":               e.Key,
+			"url":               e.URL,
+			"prometheus_user":   e.PrometheusUser,
+			"prometheus_url":    e.PrometheusURL,
+			"loki_user":         e.LokiUser,
+			"loki_url":          e.LokiURL,
+			"tempo_user":        e.TempoUser,
+			"tempo_url":         e.TempoURL,
+			"alertmanager_user": e.AlertmanagerUser,
+			"alertmanager_url":  e.AlertmanagerURL,
+			"graphite_user":     e.GraphiteUser,
+			"graphite_url":      e.GraphiteURL,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Context, req)
@@ -109,7 +127,18 @@ func (e *testEnv) ReadUserToken(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NotEmpty(t, resp.Secret.InternalData["name"])
 	require.NotNil(t, resp.Secret)
-	require.Equal(t, testUser, resp.Data["user"])
+	require.Equal(t, testPrometheusUser, resp.Data["user"])
+	require.Equal(t, testPrometheusUser, resp.Data["prometheus_user"])
+	require.Equal(t, testLokiUser, resp.Data["loki_user"])
+	require.Equal(t, testTempoUser, resp.Data["tempo_user"])
+	require.Equal(t, testAlertmanagerUser, resp.Data["alertmanager_user"])
+	require.Equal(t, testGraphiteUser, resp.Data["graphite_user"])
+
+	require.Equal(t, testPrometheusUrl, resp.Data["prometheus_url"])
+	require.Equal(t, testLokiUrl, resp.Data["loki_url"])
+	require.Equal(t, testTempoUrl, resp.Data["tempo_url"])
+	require.Equal(t, testAlertmanagerUrl, resp.Data["alertmanager_url"])
+	require.Equal(t, testGraphiteUrl, resp.Data["graphite_url"])
 
 	if e.SecretToken != "" {
 		require.NotEqual(t, e.SecretToken, resp.Data["token"])

--- a/backend_test.go
+++ b/backend_test.go
@@ -15,6 +15,7 @@ const (
 	envVarGrafanaCloudOrganisation = "TEST_GRAFANA_CLOUD_ORGANISATION"
 	envVarGrafanaCloudAPIKey       = "TEST_GRAFANA_CLOUD_API_KEY"
 	envVarGrafanaCloudURL          = "TEST_GRAFANA_CLOUD_URL"
+	envVarCATarPath                = "TEST_GRAFANA_CLOUD_CA_TAR_PATH"
 )
 
 // getTestBackend will help you construct a test backend object.

--- a/grafanacloud_key.go
+++ b/grafanacloud_key.go
@@ -13,9 +13,19 @@ import (
 )
 
 type GrafanaCloudKey struct {
-	Name  string
-	Token string
-	User  string
+	Name             string
+	Token            string
+	User             string
+	PrometheusUser   string
+	PrometheusURL    string
+	LokiUser         string
+	LokiURL          string
+	TempoUser        string
+	TempoURL         string
+	AlertmanagerUser string
+	AlertmanagerURL  string
+	GraphiteUser     string
+	GraphiteURL      string
 }
 
 func (b *grafanaCloudBackend) grafanaCloudKey() *framework.Secret {
@@ -85,7 +95,7 @@ func (b *grafanaCloudBackend) keyRenew(ctx context.Context, req *logical.Request
 	return resp, nil
 }
 
-func createKey(ctx context.Context, c *client.Client, organisation, roleName, user, grafanaCloudRole string) (*GrafanaCloudKey, error) {
+func createKey(ctx context.Context, c *client.Client, organisation, roleName string, config *grafanaCloudConfig, grafanaCloudRole string) (*GrafanaCloudKey, error) {
 	suffix := uuid.New().String()
 	tokenName := fmt.Sprintf("%s_%s", roleName, suffix)
 
@@ -100,8 +110,18 @@ func createKey(ctx context.Context, c *client.Client, organisation, roleName, us
 	}
 
 	return &GrafanaCloudKey{
-		Name:  key.Name,
-		Token: key.Token,
-		User:  user,
+		Name:             key.Name,
+		Token:            key.Token,
+		User:             config.User,
+		PrometheusUser:   config.PrometheusUser,
+		PrometheusURL:    config.PrometheusURL,
+		LokiUser:         config.LokiUser,
+		LokiURL:          config.LokiURL,
+		TempoUser:        config.TempoUser,
+		TempoURL:         config.TempoURL,
+		AlertmanagerUser: config.AlertmanagerUser,
+		AlertmanagerURL:  config.AlertmanagerURL,
+		GraphiteUser:     config.GraphiteUser,
+		GraphiteURL:      config.GraphiteURL,
 	}, nil
 }

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -3,9 +3,10 @@ package secretsengine
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const (
@@ -55,6 +56,56 @@ func TestConfig(t *testing.T) {
 			assert.Error(t, err)
 		})
 
+		t.Run("Create Configuration - invalid prometheus url", func(t *testing.T) {
+			err := testConfigCreate(b, reqStorage, map[string]interface{}{
+				"key":            key,
+				"url":            configUrl,
+				"organisation":   organisation,
+				"prometheus_url": "/p",
+			})
+			assert.Error(t, err)
+		})
+
+		t.Run("Create Configuration - invalid loki url", func(t *testing.T) {
+			err := testConfigCreate(b, reqStorage, map[string]interface{}{
+				"key":          key,
+				"url":          configUrl,
+				"organisation": organisation,
+				"loki_url":     "/l",
+			})
+			assert.Error(t, err)
+		})
+
+		t.Run("Create Configuration - invalid tempo url", func(t *testing.T) {
+			err := testConfigCreate(b, reqStorage, map[string]interface{}{
+				"key":          key,
+				"url":          configUrl,
+				"organisation": organisation,
+				"tempo_url":    "/t",
+			})
+			assert.Error(t, err)
+		})
+
+		t.Run("Create Configuration - invalid alertmanager url", func(t *testing.T) {
+			err := testConfigCreate(b, reqStorage, map[string]interface{}{
+				"key":              key,
+				"url":              configUrl,
+				"organisation":     organisation,
+				"alertmanager_url": "/a",
+			})
+			assert.Error(t, err)
+		})
+
+		t.Run("Create Configuration - invalid graphite url", func(t *testing.T) {
+			err := testConfigCreate(b, reqStorage, map[string]interface{}{
+				"key":          key,
+				"url":          configUrl,
+				"organisation": organisation,
+				"graphite_url": "/g",
+			})
+			assert.Error(t, err)
+		})
+
 		t.Run("Create Configuration - empty organisation", func(t *testing.T) {
 			err := testConfigCreate(b, reqStorage, map[string]interface{}{
 				"key":          key,
@@ -66,20 +117,39 @@ func TestConfig(t *testing.T) {
 
 		t.Run("Read Configuration - pass", func(t *testing.T) {
 			err := testConfigRead(b, reqStorage, map[string]interface{}{
-				"key":          key,
-				"url":          configUrl,
-				"organisation": organisation,
-				"user":         "",
+				"key":               key,
+				"url":               configUrl,
+				"organisation":      organisation,
+				"user":              "",
+				"prometheus_user":   "",
+				"prometheus_url":    "",
+				"loki_user":         "",
+				"loki_url":          "",
+				"tempo_user":        "",
+				"tempo_url":         "",
+				"alertmanager_user": "",
+				"alertmanager_url":  "",
+				"graphite_user":     "",
+				"graphite_url":      "",
 			})
 			assert.NoError(t, err)
 		})
 
-		t.Run("Update Configuration - pass", func(t *testing.T) {
+		t.Run("Update Configuration (set users and urls) - pass", func(t *testing.T) {
 			err := testConfigUpdate(b, reqStorage, map[string]interface{}{
-				"key":          key,
-				"url":          "http://grafanacloud:19090",
-				"organisation": organisation1,
-				"user":         "1234",
+				"key":               key,
+				"url":               "http://grafanacloud:19090",
+				"organisation":      organisation1,
+				"user":              "1",
+				"prometheus_url":    "http://prometheus",
+				"loki_user":         "2",
+				"loki_url":          "http://loki",
+				"tempo_user":        "3",
+				"tempo_url":         "http://tempo",
+				"alertmanager_user": "4",
+				"alertmanager_url":  "http://alertmanager",
+				"graphite_user":     "5",
+				"graphite_url":      "http://graphite",
 			})
 			assert.NoError(t, err)
 		})
@@ -91,12 +161,52 @@ func TestConfig(t *testing.T) {
 			assert.Error(t, err)
 		})
 
-		t.Run("Read Updated Configuration - pass", func(t *testing.T) {
+		t.Run("Read Updated Configuration (set users and urls) - pass", func(t *testing.T) {
 			err := testConfigRead(b, reqStorage, map[string]interface{}{
-				"key":          key,
-				"url":          "http://grafanacloud:19090",
-				"organisation": organisation1,
-				"user":         "1234",
+				"key":               key,
+				"url":               "http://grafanacloud:19090",
+				"organisation":      organisation1,
+				"user":              "1",
+				"prometheus_user":   "",
+				"prometheus_url":    "http://prometheus",
+				"loki_user":         "2",
+				"loki_url":          "http://loki",
+				"tempo_user":        "3",
+				"tempo_url":         "http://tempo",
+				"alertmanager_user": "4",
+				"alertmanager_url":  "http://alertmanager",
+				"graphite_user":     "5",
+				"graphite_url":      "http://graphite",
+			})
+			assert.NoError(t, err)
+		})
+
+		t.Run("Update Configuration (set prometheus_user) - pass", func(t *testing.T) {
+			err := testConfigUpdate(b, reqStorage, map[string]interface{}{
+				"key":             key,
+				"url":             "http://grafanacloud:19090",
+				"organisation":    organisation1,
+				"prometheus_user": "6",
+			})
+			assert.NoError(t, err)
+		})
+
+		t.Run("Read Updated Configuration (set prometheus_user) - pass", func(t *testing.T) {
+			err := testConfigRead(b, reqStorage, map[string]interface{}{
+				"key":               key,
+				"url":               "http://grafanacloud:19090",
+				"organisation":      organisation1,
+				"user":              "6",
+				"prometheus_user":   "6",
+				"prometheus_url":    "http://prometheus",
+				"loki_user":         "2",
+				"loki_url":          "http://loki",
+				"tempo_user":        "3",
+				"tempo_url":         "http://tempo",
+				"alertmanager_user": "4",
+				"alertmanager_url":  "http://alertmanager",
+				"graphite_user":     "5",
+				"graphite_url":      "http://graphite",
 			})
 			assert.NoError(t, err)
 		})

--- a/path_credentials.go
+++ b/path_credentials.go
@@ -52,7 +52,7 @@ func (b *grafanaCloudBackend) createKey(ctx context.Context, s logical.Storage, 
 	}
 
 	var token *GrafanaCloudKey
-	token, err = createKey(ctx, client, config.Organisation, roleName, config.User, roleEntry.GrafanaCloudRole)
+	token, err = createKey(ctx, client, config.Organisation, roleName, config, roleEntry.GrafanaCloudRole)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating Grafana Cloud token: %w", err)
@@ -77,6 +77,46 @@ func (b *grafanaCloudBackend) createUserCreds(ctx context.Context, req *logical.
 
 	if key.User != "" {
 		responseData["user"] = key.User
+	}
+
+	if key.PrometheusUser != "" {
+		responseData["prometheus_user"] = key.PrometheusUser
+	}
+
+	if key.LokiUser != "" {
+		responseData["loki_user"] = key.LokiUser
+	}
+
+	if key.TempoUser != "" {
+		responseData["tempo_user"] = key.TempoUser
+	}
+
+	if key.AlertmanagerUser != "" {
+		responseData["alertmanager_user"] = key.AlertmanagerUser
+	}
+
+	if key.GraphiteUser != "" {
+		responseData["graphite_user"] = key.GraphiteUser
+	}
+
+	if key.PrometheusURL != "" {
+		responseData["prometheus_url"] = key.PrometheusURL
+	}
+
+	if key.LokiURL != "" {
+		responseData["loki_url"] = key.LokiURL
+	}
+
+	if key.TempoURL != "" {
+		responseData["tempo_url"] = key.TempoURL
+	}
+
+	if key.AlertmanagerURL != "" {
+		responseData["alertmanager_url"] = key.AlertmanagerURL
+	}
+
+	if key.GraphiteURL != "" {
+		responseData["graphite_url"] = key.GraphiteURL
 	}
 
 	resp := b.Secret(grafanaCloudKeyType).Response(

--- a/path_credentials_test.go
+++ b/path_credentials_test.go
@@ -11,7 +11,18 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-const testUser = "1234"
+const (
+	testPrometheusUser   = "1"
+	testLokiUser         = "2"
+	testTempoUser        = "3"
+	testAlertmanagerUser = "4"
+	testGraphiteUser     = "5"
+	testPrometheusUrl    = "http://prometheus"
+	testLokiUrl          = "http://loki"
+	testTempoUrl         = "http://tempo"
+	testAlertmanagerUrl  = "http://alertmanager"
+	testGraphiteUrl      = "http://graphite"
+)
 
 // newAcceptanceTestEnv creates a test environment for credentials
 func newAcceptanceTestEnv() (*testEnv, error) {
@@ -31,13 +42,23 @@ func newAcceptanceTestEnv() (*testEnv, error) {
 		return nil, err
 	}
 	return &testEnv{
-		Organisation: os.Getenv(envVarGrafanaCloudOrganisation),
-		Key:          os.Getenv(envVarGrafanaCloudAPIKey),
-		URL:          os.Getenv(envVarGrafanaCloudURL),
-		User:         testUser,
-		Backend:      b,
-		Context:      ctx,
-		Storage:      &logical.InmemStorage{},
+		Organisation:     os.Getenv(envVarGrafanaCloudOrganisation),
+		Key:              os.Getenv(envVarGrafanaCloudAPIKey),
+		URL:              os.Getenv(envVarGrafanaCloudURL),
+		PrometheusUser:   testPrometheusUser,
+		PrometheusURL:    testPrometheusUrl,
+		LokiUser:         testLokiUser,
+		LokiURL:          testLokiUrl,
+		TempoUser:        testTempoUser,
+		TempoURL:         testTempoUrl,
+		AlertmanagerUser: testAlertmanagerUser,
+		AlertmanagerURL:  testAlertmanagerUrl,
+		GraphiteUser:     testGraphiteUser,
+		GraphiteURL:      testGraphiteUrl,
+
+		Backend: b,
+		Context: ctx,
+		Storage: &logical.InmemStorage{},
 	}, nil
 }
 

--- a/stepwise_test.go
+++ b/stepwise_test.go
@@ -1,11 +1,18 @@
 package secretsengine
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
 	stepwise "github.com/hashicorp/vault-testing-stepwise"
 	dockerEnvironment "github.com/hashicorp/vault-testing-stepwise/environments/docker"
 	"github.com/hashicorp/vault/api"
@@ -34,6 +41,7 @@ func TestAccUserToken(t *testing.T) {
 		Precheck:    func() { testAccPreCheck(t) },
 		Environment: dockerEnvironment.NewEnvironment("grafana-cloud", envOptions),
 		Steps: []stepwise.Step{
+			testAddCA(t),
 			testAccConfig(t),
 			testAccUserRole(t, roleName),
 			testAccUserRoleRead(t, roleName),
@@ -59,6 +67,96 @@ func testAccPreCheck(t *testing.T) {
 	})
 }
 
+// testAddCA will add (if given) the CA tar to the vault container.
+func testAddCA(t *testing.T) stepwise.Step {
+	return stepwise.Step{
+		Operation: stepwise.HelpOperation,
+		Assert: func(_ *api.Secret, _ error) error {
+			caPath := os.Getenv(envVarCATarPath)
+			if caPath == "" {
+				return nil
+			}
+
+			cli, err := client.NewClientWithOpts()
+			if err != nil {
+				return fmt.Errorf("failed to create new Docker CLI client: %s", err.Error())
+			}
+
+			container, err := fetchVaultContainer(cli)
+			if err != nil {
+				return err
+			}
+
+			if err := copyCATarToContainer(cli, caPath, container); err != nil {
+				return err
+			}
+
+			return updateContainerCACertificates(cli, container)
+		},
+	}
+}
+
+// fetchVaultContainer will attempt to find the vault container started by stepwise.
+func fetchVaultContainer(cli client.APIClient) (types.Container, error) {
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{
+		Filters: filters.NewArgs(
+			filters.KeyValuePair{
+				Key:   "name",
+				Value: "test-grafana-cloud-*",
+			},
+		),
+	})
+	if err != nil {
+		return types.Container{}, fmt.Errorf("failed to list containers: %s", err.Error())
+	}
+
+	for _, container := range containers {
+		if strings.HasSuffix(container.Names[0], "vault-0") {
+			return container, nil
+		}
+	}
+
+	return types.Container{}, errors.New("could not find container 'test-grafana-cloud-*-vault-0")
+}
+
+// copyCATarToContainer will attempt to read the given file and copy it to the container.
+func copyCATarToContainer(cli client.APIClient, caPath string, container types.Container) error {
+	caBytes, err := os.ReadFile(caPath)
+	if err != nil {
+		return fmt.Errorf("failed to read CA tar file: %s", err.Error())
+	}
+
+	if err := cli.CopyToContainer(
+		context.Background(),
+		container.ID,
+		"/usr/local/share/ca-certificates/",
+		bytes.NewReader(caBytes),
+		types.CopyToContainerOptions{}); err != nil {
+
+		return fmt.Errorf("failed to copy file to container: %s", err.Error())
+	}
+
+	return nil
+}
+
+// updateContainerCACertificates will run the update-ca-certificates command within the container.
+func updateContainerCACertificates(cli client.APIClient, container types.Container) error {
+	exec, err := cli.ContainerExecCreate(context.Background(), container.ID, types.ExecConfig{
+		Cmd: []string{
+			"update-ca-certificates",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create container exec command: %s", err.Error())
+	}
+
+	if err := cli.ContainerExecStart(context.Background(), exec.ID, types.ExecStartCheck{}); err != nil {
+		return fmt.Errorf("failed to run container exec command: %s", err.Error())
+	}
+
+	return nil
+}
+
 func testAccConfig(t *testing.T) stepwise.Step {
 	return stepwise.Step{
 		Operation: stepwise.UpdateOperation,
@@ -81,8 +179,8 @@ func testAccUserRole(t *testing.T, roleName string) stepwise.Step {
 			"max_ttl": "5m",
 		},
 		Assert: func(resp *api.Secret, err error) error {
-			require.Nil(t, resp)
 			require.Nil(t, err)
+			require.Nil(t, resp)
 			return nil
 		},
 	}
@@ -93,6 +191,7 @@ func testAccUserRoleRead(t *testing.T, roleName string) stepwise.Step {
 		Operation: stepwise.ReadOperation,
 		Path:      "roles/" + roleName,
 		Assert: func(resp *api.Secret, err error) error {
+			require.Nil(t, err)
 			require.NotNil(t, resp)
 			require.Equal(t, "Viewer", resp.Data["gc_role"])
 			return nil
@@ -105,6 +204,7 @@ func testAccUserCredRead(t *testing.T, roleName string, apiKey *string) stepwise
 		Operation: stepwise.ReadOperation,
 		Path:      "creds/" + roleName,
 		Assert: func(resp *api.Secret, err error) error {
+			require.Nil(t, err)
 			require.NotNil(t, resp)
 			require.NotEmpty(t, resp.Data["token"])
 			*apiKey = resp.Data["token"].(string)


### PR DESCRIPTION
This PR adds config to the backend to provide user IDs and URLs for the Grafana Cloud resources:
* Prometheus
* Loki
* Tempo
* Alertmanager
* Graphite

Any provided users/urls will be populated in credentials when they are generated. This will allow consuming applications to use the token in the right places, with the correct user ID.

This PR also adds an integration step to provide a CA certificate to the Vault container that integration tests are performed against.

Closes https://github.com/form3tech-oss/vault-plugin-secrets-grafanacloud/issues/11
Closes https://github.com/form3tech-oss/vault-plugin-secrets-grafanacloud/issues/10