### PR TITLE
chore: configure TLS server name

### DIFF
--- a/cmd/vault-plugin-secrets-grafanacloud/main.go
+++ b/cmd/vault-plugin-secrets-grafanacloud/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsConfig.TLSServerName = "vault.platform.svc"
+	tlsConfig.Insecure = true
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	err := plugin.Serve(&plugin.ServeOpts{

--- a/cmd/vault-plugin-secrets-grafanacloud/main.go
+++ b/cmd/vault-plugin-secrets-grafanacloud/main.go
@@ -21,8 +21,9 @@ func main() {
 	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
-	tlsConfig.TLSServerName = "vault.platform.svc"
-	tlsConfig.Insecure = true
+	if e := os.Getenv("VAULT_GRAFANACLOUD_TLS_SERVER_NAME"); e != "" {
+		tlsConfig.TLSServerName = e
+	}
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	err := plugin.Serve(&plugin.ServeOpts{

--- a/cmd/vault-plugin-secrets-grafanacloud/main.go
+++ b/cmd/vault-plugin-secrets-grafanacloud/main.go
@@ -21,6 +21,7 @@ func main() {
 	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
+	tlsConfig.TLSServerName = "vault.platform.svc"
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
 	err := plugin.Serve(&plugin.ServeOpts{


### PR DESCRIPTION
Configure TLS server name `vault.platform.svc`.